### PR TITLE
Gx 5926

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 terraform.tfstate*
 terraform.tfvars
 values.dev.yaml
+secrets.yaml

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -67,7 +67,10 @@ spec:
       {{- if .Values.client.hostNetwork }}
       hostNetwork: {{ .Values.client.hostNetwork }}
       {{- end }}
-
+      {{- if .Values.privateRegistry.secret }}
+      imagePullSecrets:
+      - name: {{ .Values.privateRegistry.secret }}
+      {{- end }}
       volumes:
         - name: data
         {{- if .Values.client.dataDirectoryHostPath }}
@@ -346,7 +349,8 @@ spec:
       {{- end }}
       {{- if and .Values.global.tls.enabled (not .Values.global.tls.enableAutoEncrypt) }}
       - name: client-tls-init
-        image: "{{ default .Values.global.image .Values.client.image }}"
+        image: "{{ default .Values.global.image .Values.client.mkcerts.image }}"
+        imagePullPolicy: Always
         env:
         - name: HOST_IP
           valueFrom:
@@ -360,16 +364,22 @@ spec:
           - "/bin/sh"
           - "-ec"
           - |
+            cat > /consul/tls/client/config.json << EOF
+              {
+                "ips": [
+                  "${POD_IP}",
+                  "${HOST_IP}"
+                ]
+              }
+            EOF
+
             cd /consul/tls/client
-            consul tls cert create -client \
-              -additional-ipaddress=${HOST_IP} \
-              -additional-ipaddress=${POD_IP} \
-              -dc={{ .Values.global.datacenter }} \
-              -domain={{ .Values.global.domain }} \
-              -ca=/consul/tls/ca/cert/tls.crt \
-              -key=/consul/tls/ca/key/tls.key
-            mv {{ .Values.global.datacenter }}-client-{{ .Values.global.domain }}-0.pem tls.crt
-            mv {{ .Values.global.datacenter }}-client-{{ .Values.global.domain }}-0-key.pem tls.key
+            mkcerts --cn "Calculi GR service" \
+              --in.cert /consul/tls/ca/cert/tls.crt \
+              --in.key /consul/tls/ca/key/tls.key \
+              --f tls \
+              --type client_server \
+              --configfile /consul/tls/client/config.json
         volumeMounts:
           - name: consul-client-cert
             mountPath: /consul/tls/client

--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -380,6 +380,9 @@ spec:
               --f tls \
               --type client_server \
               --configfile /consul/tls/client/config.json
+
+              mv tls.cert.pem tls.crt
+              mv tls.key.pem tls.key
         volumeMounts:
           - name: consul-client-cert
             mountPath: /consul/tls/client

--- a/templates/private-docker-registry.yaml
+++ b/templates/private-docker-registry.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.privateRegistry.secret }}
+{{- $imagePullSecret := printf "{\"insecure-registries\" : [\"%s\"], \"auths\":{\"%s\": {\"username\":\"%s\",\"password\":\"%s\"}}}" .Values.privateRegistry.url .Values.privateRegistry.url .Values.privateRegistry.username .Values.privateRegistry.password | b64enc }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.privateRegistry.secret }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{$imagePullSecret}}
+{{- end }}

--- a/templates/secret-ca-cert.yaml
+++ b/templates/secret-ca-cert.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.global.tls.enabled }}
+{{- if .Values.global.tls.caCert -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.tls.caCert.secretName }}
+type: Opaque
+data:
+  tls.crt: {{ .Values.global.tls.caCert.cert | b64enc }}
+{{- end }}
+{{- end }}

--- a/templates/secret-ca-key.yaml
+++ b/templates/secret-ca-key.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.global.tls.enabled }}
+{{- if .Values.global.tls.caKey -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.global.tls.caKey.secretName }}
+type: Opaque
+data:
+  tls.key: {{ .Values.global.tls.caKey.key | b64enc }}
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -148,6 +148,7 @@ global:
       secretName: consul-ca-cert
       # The key of the Kubernetes secret.
       secretKey: tls.crt
+      cert:
 
     # A Kubernetes secret containing the private key of the CA to use for
     # TLS communication within the Consul cluster. If you have generated the CA yourself
@@ -168,6 +169,7 @@ global:
       secretName: consul-ca-key
       # The key of the Kubernetes secret.
       secretKey: tls.key
+      key:
 
   # [Enterprise Only] `enableConsulNamespaces` indicates that you are running
   # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would
@@ -1213,7 +1215,7 @@ syncCatalog:
 connectInject:
   # True if you want to enable connect injection. Set to "-" to inherit from
   # global.enabled.
-  enabled: false
+  enabled: true
 
   # Image for consul-k8s that contains the injector
   # @type: string
@@ -1224,7 +1226,7 @@ connectInject:
   # injection annotation (https://consul.io/docs/k8s/connect#consul-hashicorp-com-connect-inject)
   # to opt-in to Connect injection. If this is true, pods can use the same annotation
   # to explicitly opt-out of injection.
-  default: false
+  default: true
 
   # Enables synchronization of Kubernetes health probe status with Consul.
   # NOTE: It is highly recommended to enable TLS with this feature because it requires

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,11 @@
 # Available parameters and their default values for the Consul chart.
 
+privateRegistry:
+  secret: registry
+  url: docker.calculi.io
+  username:
+  password:
+
 # Holds values that affect multiple components of the chart.
 global:
   # The main enabled/disabled setting. If true, servers,
@@ -7,7 +13,7 @@ global:
   # this default via its component-specific "enabled" config. If false, no components
   # will be installed by default and per-component opt-in is required, such as by
   # setting `server.enabled` to true.
-  enabled: true
+  enabled: false
 
   # Set the prefix used for all resources in the Helm chart. If not set,
   # the prefix will be `<helm release name>-consul`.
@@ -58,7 +64,7 @@ global:
   # register as. This can't be changed once the Consul cluster is up and running
   # since Consul doesn't support an automatic way to change this value currently:
   # https://github.com/hashicorp/consul/issues/1858.
-  datacenter: dc1
+  datacenter: calculi
 
   # Controls whether pod security policies are created for the Consul components
   # created by this chart. See https://kubernetes.io/docs/concepts/policy/pod-security-policy/.
@@ -98,7 +104,7 @@ global:
     # If true, the Helm chart will enable TLS for Consul
     # servers and clients and all consul-k8s components, as well as generate certificate
     # authority (optional) and server and client certificates.
-    enabled: false
+    enabled: true
 
     # If true, turns on the auto-encrypt feature on clients and servers.
     # It also switches consul-k8s components to retrieve the CA from the servers
@@ -139,9 +145,9 @@ global:
     # ```
     caCert:
       # The name of the Kubernetes secret.
-      secretName: null
+      secretName: consul-ca-cert
       # The key of the Kubernetes secret.
-      secretKey: null
+      secretKey: tls.crt
 
     # A Kubernetes secret containing the private key of the CA to use for
     # TLS communication within the Consul cluster. If you have generated the CA yourself
@@ -159,9 +165,9 @@ global:
     # certificates.
     caKey:
       # The name of the Kubernetes secret.
-      secretName: null
+      secretName: consul-ca-key
       # The key of the Kubernetes secret.
-      secretKey: null
+      secretKey: tls.key
 
   # [Enterprise Only] `enableConsulNamespaces` indicates that you are running
   # Consul Enterprise v1.7+ with a valid Consul Enterprise license and would
@@ -614,13 +620,15 @@ client:
   # `server.enabled`, since the agents can be configured to join an external cluster.
   # @default: global.enabled
   # @type: boolean
-  enabled: "-"
+  enabled: true
 
   # The name of the Docker image (including any tag) for the containers
   # running Consul client agents.
   # @type: string
   image: null
 
+  mkcerts:
+    image: docker.calculi.io/mkcerts  
   # A list of valid `-retry-join` values (https://consul.io/docs/agent/options#retry-join).
   # If this is `null` (default), then the clients will attempt to automatically
   # join the server cluster running within Kubernetes.
@@ -628,7 +636,10 @@ client:
   # join that cluster. If `server.enabled` is not true, then a value must be
   # specified so the clients can join a valid cluster.
   # @type: array<string>
-  join: null
+  join:
+    - 10.128.1.11
+    - 10.128.2.12
+    - 10.129.0.13
 
   # An absolute path to a directory on the host machine to use as the Consul
   # client data directory. If set to the empty string or null, the Consul agent

--- a/values.yaml
+++ b/values.yaml
@@ -639,9 +639,6 @@ client:
   # specified so the clients can join a valid cluster.
   # @type: array<string>
   join:
-    - 10.128.1.11
-    - 10.128.2.12
-    - 10.129.0.13
 
   # An absolute path to a directory on the host machine to use as the Consul
   # client data directory. If set to the empty string or null, the Consul agent


### PR DESCRIPTION
NOTE: Usage of mkcerts instead of the consul TLS command, as it does not support creation of 384 bit private keys. Also added some templates to generate secrets as part of the same HELM chart - this is required so users don't end up having to write their secrets outside of the chart execution.